### PR TITLE
Refactor: split clipboard utilities

### DIFF
--- a/wkey/clipboard_utils.py
+++ b/wkey/clipboard_utils.py
@@ -1,0 +1,89 @@
+import ctypes
+import logging
+import time
+import win32clipboard
+
+from voice_commands import execute_command_run_with_tool
+
+PASTE_BEEP = (1060, 100)
+
+
+def set_clipboard_content(text: str) -> None:
+    """Place ``text`` onto the Windows clipboard."""
+    try:
+        success = False
+        while not success:
+            try:
+                win32clipboard.OpenClipboard(0)
+                win32clipboard.EmptyClipboard()
+                win32clipboard.SetClipboardText(text)
+                win32clipboard.CloseClipboard()
+                success = True
+            except win32clipboard.Error:
+                logging.info(
+                    "Failed to open the clipboard. Retrying in 1 second..."
+                )
+                time.sleep(0.5)
+    except Exception as exc:  # pragma: no cover - just logging
+        logging.error("Error in set_clipboard_content: %s", exc, exc_info=True)
+
+
+def get_clipboard_content() -> str:
+    """Return the current string content from the Windows clipboard."""
+    try:
+        win32clipboard.OpenClipboard(0)
+        data = win32clipboard.GetClipboardData()
+        win32clipboard.CloseClipboard()
+        return data
+    except win32clipboard.Error:
+        logging.info(
+            "Failed to open the clipboard. Returning an empty string."
+        )
+        return ""
+    except Exception as exc:  # pragma: no cover - just logging
+        logging.error("Error in get_clipboard_content: %s", exc, exc_info=True)
+        return ""
+
+
+def send_input(text: str) -> None:
+    """Simulate keyboard input of ``text``."""
+    try:
+        for char in text:
+            ctypes.windll.user32.keybd_event(ord(char.upper()), 0, 0, 0)
+            ctypes.windll.user32.keybd_event(ord(char.upper()), 0, 2, 0)
+    except Exception as exc:  # pragma: no cover - just logging
+        logging.error("Error in send_input: %s", exc, exc_info=True)
+
+
+def paste_transcript(transcript: str, beep_func=None) -> None:
+    """Paste ``transcript`` to the active window and optionally beep."""
+    try:
+        set_clipboard_content(transcript)
+        ctypes.windll.user32.keybd_event(0x11, 0, 0, 0)
+        ctypes.windll.user32.keybd_event(0x56, 0, 0, 0)
+        ctypes.windll.user32.keybd_event(0x56, 0, 2, 0)
+        ctypes.windll.user32.keybd_event(0x11, 0, 2, 0)
+        if beep_func:
+            beep_func(PASTE_BEEP)
+        logging.info("Transcript pasted")
+    except Exception as exc:  # pragma: no cover - just logging
+        logging.error("Error in paste_transcript: %s", exc, exc_info=True)
+
+
+def run_command_with_retry(transcript: str, max_retries: int = 3) -> None:
+    """Attempt to execute ``transcript`` as a command, retrying on failure."""
+    try:
+        for _ in range(max_retries):
+            try:
+                if execute_command_run_with_tool(transcript):
+                    return
+            except Exception as exc:  # pragma: no cover - just logging
+                logging.error(
+                    "Error in execute_command_run_with_tool: %s", exc, exc_info=True
+                )
+            time.sleep(2)
+        logging.error(
+            "Failed to execute command after %s attempts", max_retries
+        )
+    except Exception as exc:  # pragma: no cover - just logging
+        logging.error("Error in run_command_with_retry: %s", exc, exc_info=True)

--- a/wkey/faster_whisper_Mother_of_all_wkey.py
+++ b/wkey/faster_whisper_Mother_of_all_wkey.py
@@ -41,8 +41,7 @@ from pause_all import is_sound_playing_windows_processing
 import pyaudio
 from openwakeword.model import Model
 from concurrent.futures import ThreadPoolExecutor
-import win32clipboard
-import ctypes
+from .clipboard_utils import paste_transcript
 import webrtcvad
 from voice_activity_detection import VoiceDetector
 import sys
@@ -137,7 +136,6 @@ wake_stream.start_stream()
 # Define beep sounds
 START_BEEP = (2080, 100)
 STOP_BEEP = (440, 100)
-PASTE_BEEP = (1060, 100)
 
 # Locks for synchronization
 recording_lock = threading.Lock()
@@ -953,7 +951,7 @@ async def process_audio_async():
 
             if keyword_index is None:
                 logging.info("pasing f24 transcription")
-                paste_transcript(transcript)
+                paste_transcript(transcript, beep)
                 continue
             elif keyword_index == 1:
                 if "computer" in transcript_lower:
@@ -971,7 +969,7 @@ async def process_audio_async():
                         keyword_position + len("lama") :
                     ]
                     logging.info(f"Processing lama command: {stripped_transcript}")
-                    paste_transcript(stripped_transcript)
+                    paste_transcript(stripped_transcript, beep)
                     continue
             elif keyword_index == 3:
                 if "google" in transcript_lower:
@@ -1041,7 +1039,7 @@ async def process_transcript(transcript, keyword_index, audio_buffer):
     try:
         if keyword_index is None:
             if len(transcript) > 3:
-                paste_transcript(transcript)
+                paste_transcript(transcript, beep)
         elif keyword_index == 1 and "computer" in transcript:
             keyword_pos = transcript.index("computer")
             stripped = transcript[key_pos + len("computer") :].strip()
@@ -1051,7 +1049,7 @@ async def process_transcript(transcript, keyword_index, audio_buffer):
             keyword_pos = transcript.index("lama")
             stripped = transcript[key_pos + len("lama") :].strip()
             if stripped:
-                paste_transcript(stripped)
+                paste_transcript(stripped, beep)
         else:
             logging.info(f"{YELLOW}No matching keyword found in transcript{RESET}")
     except Exception as e:
@@ -1114,69 +1112,6 @@ def monitor_state():
  ######  ######## #### ##        ########   #######  ##     ## ##     ## ########  
 """
 
-def set_clipboard_content(text):
-    try:
-        success = False
-        while not success:
-            try:
-                win32clipboard.OpenClipboard(0)
-                win32clipboard.EmptyClipboard()
-                win32clipboard.SetClipboardText(text)
-                win32clipboard.CloseClipboard()
-                success = True
-            except win32clipboard.Error:
-                logging.info("Failed to open the clipboard. Retrying in 1 second...")
-                time.sleep(0.5)
-    except Exception as e:
-        logging.error(f"Error in set_clipboard_content: {e}", exc_info=True)
-
-def get_clipboard_content():
-    try:
-        win32clipboard.OpenClipboard(0)
-        data = win32clipboard.GetClipboardData()
-        win32clipboard.CloseClipboard()
-        return data
-    except win32clipboard.Error:
-        logging.info("Failed to open the clipboard. Returning an empty string.")
-        return ""
-    except Exception as e:
-        logging.error(f"Error in get_clipboard_content: {e}", exc_info=True)
-
-def send_input(text):
-    try:
-        for char in text:
-            ctypes.windll.user32.keybd_event(ord(char.upper()), 0, 0, 0)
-            ctypes.windll.user32.keybd_event(ord(char.upper()), 0, 2, 0)
-    except Exception as e:
-        logging.error(f"Error in send_input: {e}", exc_info=True)
-
-def paste_transcript(transcript):
-    try:
-        set_clipboard_content(transcript)
-        ctypes.windll.user32.keybd_event(0x11, 0, 0, 0)
-        ctypes.windll.user32.keybd_event(0x56, 0, 0, 0)
-        ctypes.windll.user32.keybd_event(0x56, 0, 2, 0)
-        ctypes.windll.user32.keybd_event(0x11, 0, 2, 0)
-        beep(PASTE_BEEP)
-        logging.info("Transcript pasted")
-    except Exception as e:
-        logging.error(f"Error in paste_transcript: {e}", exc_info=True)
-
-def run_command_with_retry(transcript):
-    try:
-        max_retries = 3
-        for attempt in range(max_retries):
-            try:
-                if execute_command_run_with_tool(transcript):
-                    return
-            except Exception as e:
-                logging.error(
-                    f"Error in execute_command_run_with_tool: {e}", exc_info=True
-                )
-            time.sleep(2)
-        logging.error(f"Failed to execute command after {max_retries} attempts")
-    except Exception as e:
-        logging.error(f"Error in run_command_with_retry: {e}", exc_info=True)
 
 async def clean_transcript():
     try:


### PR DESCRIPTION
## Summary
- extract clipboard related helpers into `clipboard_utils`
- remove clipboard helpers from `faster_whisper_Mother_of_all_wkey.py`
- import and use new module

## Testing
- `python -m py_compile wkey/faster_whisper_Mother_of_all_wkey.py wkey/clipboard_utils.py`
- `git ls-files '*.py' -z | xargs -0 python -m py_compile` *(fails: unicode escape error in hey_llama_detection_backup.py)*

------
https://chatgpt.com/codex/tasks/task_e_6864e10be5608327936af729df805228