### PR TITLE
Add settings GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ export OPENAI_API_KEY=<your key>
 export WKEY=ctrl_r
 ```
 
-Run `wkey` in a terminal window to start listening. 
+Run `wkey` in a terminal window to start listening.
+
+### Settings GUI
+
+You can adjust transcription preferences using a small QtPy based GUI. Launch it with:
+
+```shell
+python -m wkey.Settings_GUI
+```
+
+This lets you toggle GPU usage and Groq fallback and edit your API key.
 
 If there are issues, check the additional requirements.
 

--- a/wkey/Settings_GUI.py
+++ b/wkey/Settings_GUI.py
@@ -1,0 +1,80 @@
+import os
+import json
+from qtpy.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QCheckBox,
+    QLineEdit,
+    QPushButton,
+)
+from qtpy.QtCore import Qt
+
+SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "transcription_config.json")
+DEFAULT_SETTINGS = {"use_local_gpu": True, "fallback_to_groq": True}
+
+class SettingsWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Whisper Keyboard Settings")
+        self.layout = QVBoxLayout(self)
+
+        self.use_local_cb = QCheckBox("Use local GPU model when available")
+        self.use_api_cb = QCheckBox("Fallback to Groq API")
+        self.api_key_edit = QLineEdit()
+        self.api_key_edit.setPlaceholderText("GROQ_API_KEY")
+
+        self.layout.addWidget(self.use_local_cb)
+        self.layout.addWidget(self.use_api_cb)
+        self.layout.addWidget(QLabel("Groq API Key:"))
+        self.layout.addWidget(self.api_key_edit)
+
+        btn_layout = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        save_btn.clicked.connect(self.save_settings)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        btn_layout.addWidget(save_btn)
+        btn_layout.addWidget(close_btn)
+        self.layout.addLayout(btn_layout)
+
+        self.load_settings()
+
+    def load_settings(self):
+        config = DEFAULT_SETTINGS.copy()
+        if os.path.exists(SETTINGS_PATH):
+            try:
+                with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+                    config.update(json.load(f))
+            except Exception:
+                pass
+        self.use_local_cb.setChecked(config.get("use_local_gpu", True))
+        self.use_api_cb.setChecked(config.get("fallback_to_groq", True))
+        self.api_key_edit.setText(os.environ.get("GROQ_API_KEY", ""))
+
+    def save_settings(self):
+        config = {
+            "use_local_gpu": self.use_local_cb.isChecked(),
+            "fallback_to_groq": self.use_api_cb.isChecked(),
+        }
+        try:
+            with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
+                json.dump(config, f, indent=2)
+        except Exception:
+            pass
+        if self.api_key_edit.text().strip():
+            os.environ["GROQ_API_KEY"] = self.api_key_edit.text().strip()
+        self.close()
+
+
+def main():
+    app = QApplication([])
+    window = SettingsWindow()
+    window.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/wkey/faster_whisper_Mother_of_all_wkey.py
+++ b/wkey/faster_whisper_Mother_of_all_wkey.py
@@ -50,6 +50,7 @@ from queue import Empty as QueueEmpty
 from contextlib import contextmanager
 import aiohttp
 import asyncio
+import json
 
 # Add global variables for pause functionality
 global_pause_active = False
@@ -96,6 +97,15 @@ vad_detector = VoiceDetector()
 
 load_dotenv()
 
+# Load transcription settings
+SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "transcription_config.json")
+DEFAULT_SETTINGS = {"use_local_gpu": True, "fallback_to_groq": True}
+try:
+    with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+        SETTINGS = json.load(f)
+except Exception:
+    SETTINGS = DEFAULT_SETTINGS
+
 # Get the key label from environment variables, default to 'f24' if not set
 key_label = os.environ.get("WKEY", "f24")
 # key_label = os.environ.get("WKEY", "ctrl_r")
@@ -108,13 +118,14 @@ stream = None
 audio_buffer = np.array([], dtype="float32")
 sample_rate = 16000
 
-# Check if CUDA is available
-if torch.cuda.is_available():
+# Initialize local model based on settings and GPU availability
+model = None
+if SETTINGS.get("use_local_gpu", True) and torch.cuda.is_available():
     model = WhisperModel("small.en", device="cuda", num_workers=8)
     logging.info(f"{GREEN}Initialized WhisperModel on CUDA{RESET}")
 else:
-    logging.warning(
-        f"{YELLOW}CUDA device not available. Please ensure your system supports CUDA.{RESET}"
+    logging.info(
+        f"{YELLOW}Local GPU model disabled or CUDA unavailable.{RESET}"
     )
 
 groq_model = "whisper-large-v3"
@@ -126,6 +137,9 @@ Hey_computer_STT_prompt = None
 api_key = os.getenv("GROQ_API_KEY")
 global Groq_client
 Groq_client = Groq(api_key=api_key)
+
+# Reusable HTTP session for Groq API calls
+groq_session = None
 
 p = pyaudio.PyAudio()
 wake_stream = p.open(
@@ -775,6 +789,7 @@ def listen_for_wake_word():
 def cleanup():
     try:
         global wake_stream
+        global groq_session
         if wake_stream:
             try:
                 if wake_stream.is_active():
@@ -784,6 +799,9 @@ def cleanup():
                 logging.info(f"Error during cleanup: {e}")
             wake_stream = None
         p.terminate()
+        if groq_session is not None:
+            asyncio.get_event_loop().run_until_complete(groq_session.close())
+            groq_session = None
         logging.info("Cleanup completed.")
     except Exception as e:
         logging.error(f"Error in cleanup: {e}", exc_info=True)
@@ -840,37 +858,40 @@ async def transcribe_with_groq_async(byte_io, keyword_index, max_retries=3):
         "temperature": 0.0,
     }
 
+    global groq_session
     for attempt in range(max_retries):
         try:
-            async with aiohttp.ClientSession() as session:
-                form_data = aiohttp.FormData()
-                form_data.add_field(
-                    "file",
-                    byte_io.getvalue(),
-                    filename="pre_recording.wav",
-                    content_type="audio/wav",
-                )
-                form_data.add_field("model", groq_model)
-                form_data.add_field("response_format", "json")
-                form_data.add_field("prompt", "")
-                form_data.add_field("language", "en")
-                form_data.add_field("temperature", "0.0")
+            if groq_session is None:
+                groq_session = aiohttp.ClientSession()
 
-                async with session.post(
-                    url, data=form_data, headers=headers
-                ) as response:
-                    if response.status == 404:
-                        logging.error(f"Groq API endpoint not found: {response.url}")
-                        raise aiohttp.ClientResponseError(
-                            response.request_info,
-                            response.history,
-                            status=response.status,
-                            message=response.reason,
-                            headers=response.headers,
-                        )
-                    response.raise_for_status()
-                    transcription = await response.json()
-                    return transcription["text"].lower()
+            form_data = aiohttp.FormData()
+            form_data.add_field(
+                "file",
+                byte_io.getvalue(),
+                filename="pre_recording.wav",
+                content_type="audio/wav",
+            )
+            form_data.add_field("model", groq_model)
+            form_data.add_field("response_format", "json")
+            form_data.add_field("prompt", "")
+            form_data.add_field("language", "en")
+            form_data.add_field("temperature", "0.0")
+
+            async with groq_session.post(
+                url, data=form_data, headers=headers
+            ) as response:
+                if response.status == 404:
+                    logging.error(f"Groq API endpoint not found: {response.url}")
+                    raise aiohttp.ClientResponseError(
+                        response.request_info,
+                        response.history,
+                        status=response.status,
+                        message=response.reason,
+                        headers=response.headers,
+                    )
+                response.raise_for_status()
+                transcription = await response.json()
+                return transcription["text"].lower()
         except aiohttp.ClientResponseError as e:
             logging.error(
                 f"Groq API client error: {e.status}, message='{e.message}', url='{e.request_info.url}'",
@@ -894,6 +915,9 @@ def transcribe_with_local_model(audio_buffer, keyword_index):
             prompt = None
 
         try:
+            if model is None:
+                logging.info("Local model not initialized")
+                return ""
             logging.info("using WhisperModel on CUDA")
             byte_io = io.BytesIO()
             wav_write(byte_io, sample_rate, audio_buffer)
@@ -937,15 +961,25 @@ async def process_audio_async():
             byte_io.seek(0)
 
             try:
-                transcript = await transcribe_with_groq_async(byte_io, keyword_index)
-                if transcript is None:
-                    logging.error("Transcription returned None")
-                    continue
+                transcript = None
+                if SETTINGS.get("use_local_gpu", True) and torch.cuda.is_available():
+                    transcript = transcribe_with_local_model(
+                        audio_buffer_for_processing, keyword_index
+                    )
+                    if not transcript or transcript == "Transcription failed":
+                        transcript = None
+                if transcript is None and SETTINGS.get("fallback_to_groq", True):
+                    transcript = await transcribe_with_groq_async(byte_io, keyword_index)
+                    if transcript is None:
+                        logging.error("Transcription returned None")
+                        continue
             except groq.RateLimitError:
                 logging.error(
                     "Groq API rate limit reached, switching to local transcription."
                 )
-                transcript = transcribe_with_local_model(audio_buffer_for_processing)
+                transcript = transcribe_with_local_model(
+                    audio_buffer_for_processing, keyword_index
+                )
 
             transcript_lower = transcript.lower()
 
@@ -1023,9 +1057,10 @@ def create_wav_buffer(audio_buffer):
 async def get_transcript_with_retries(byte_io, keyword_index, max_retries=3):
     for attempt in range(max_retries):
         try:
-            transcript = await transcribe_with_groq_async(byte_io, keyword_index)
-            if transcript:
-                return transcript.lower()
+            if SETTINGS.get("fallback_to_groq", True):
+                transcript = await transcribe_with_groq_async(byte_io, keyword_index)
+                if transcript:
+                    return transcript.lower()
         except Exception as e:
             logging.error(
                 f"{RED}Transcription attempt {attempt + 1} failed: {e}{RESET}"

--- a/wkey/faster_whisper_Mother_of_all_wkey_no_f24.py
+++ b/wkey/faster_whisper_Mother_of_all_wkey_no_f24.py
@@ -116,6 +116,15 @@ vad_detector = VoiceDetector()
 
 load_dotenv()
 
+# Load transcription settings
+SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "transcription_config.json")
+DEFAULT_SETTINGS = {"use_local_gpu": True, "fallback_to_groq": True}
+try:
+    with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+        SETTINGS = json.load(f)
+except Exception:
+    SETTINGS = DEFAULT_SETTINGS
+
 
 key_label = os.environ.get("WKEY", "f24")
 RECORD_KEY = Key[key_label]
@@ -135,13 +144,14 @@ stream = None
 audio_buffer = np.array([], dtype="float32")
 sample_rate = 16000
 
-# Check if CUDA is available
-if torch.cuda.is_available():
+# Initialize local model based on settings and GPU availability
+model = None
+if SETTINGS.get("use_local_gpu", True) and torch.cuda.is_available():
     model = WhisperModel("small.en", device="cuda", num_workers=8)
     logging.info(f"{GREEN}Initialized WhisperModel on CUDA{RESET}")
 else:
-    logging.warning(
-        f"{YELLOW}CUDA device not available. Please ensure your system supports CUDA.{RESET}"
+    logging.info(
+        f"{YELLOW}Local GPU model disabled or CUDA unavailable.{RESET}"
     )
 
 # groq_model = "distil-whisper-large-v3-en"
@@ -164,6 +174,9 @@ Hey_computer_STT_prompt = "
 api_key = os.getenv("GROQ_API_KEY")
 global Groq_client
 Groq_client = Groq(api_key=api_key)
+
+# Reusable HTTP session for Groq API calls
+groq_session = None
 
 
 p = pyaudio.PyAudio()
@@ -886,6 +899,7 @@ def listen_for_wake_word():
 def cleanup():
     try:
         global wake_stream
+        global groq_session
         if wake_stream:
             try:
                 if wake_stream.is_active():
@@ -895,6 +909,9 @@ def cleanup():
                 logging.info(f"Error during cleanup: {e}")
             wake_stream = None
         p.terminate()
+        if groq_session is not None:
+            asyncio.get_event_loop().run_until_complete(groq_session.close())
+            groq_session = None
         logging.info("Cleanup completed.")
     except Exception as e:
         logging.error(f"Error in cleanup: {e}", exc_info=True)
@@ -957,37 +974,40 @@ async def transcribe_with_groq_async(byte_io, keyword_index, max_retries=3):
         "temperature": 0.0,
     }
 
+    global groq_session
     for attempt in range(max_retries):
         try:
-            async with aiohttp.ClientSession() as session:
-                form_data = aiohttp.FormData()
-                form_data.add_field(
-                    "file",
-                    byte_io.getvalue(),
-                    filename="pre_recording.wav",
-                    content_type="audio/wav",
-                )
-                form_data.add_field("model", groq_model)
-                form_data.add_field("response_format", "json")
-                form_data.add_field("prompt", "")
-                form_data.add_field("language", "en")
-                form_data.add_field("temperature", "0.0")
+            if groq_session is None:
+                groq_session = aiohttp.ClientSession()
 
-                async with session.post(
-                    url, data=form_data, headers=headers
-                ) as response:
-                    if response.status == 404:
-                        logging.error(f"Groq API endpoint not found: {response.url}")
-                        raise aiohttp.ClientResponseError(
-                            response.request_info,
-                            response.history,
-                            status=response.status,
-                            message=response.reason,
-                            headers=response.headers,
-                        )
-                    response.raise_for_status()
-                    transcription = await response.json()
-                    return transcription["text"].lower()
+            form_data = aiohttp.FormData()
+            form_data.add_field(
+                "file",
+                byte_io.getvalue(),
+                filename="pre_recording.wav",
+                content_type="audio/wav",
+            )
+            form_data.add_field("model", groq_model)
+            form_data.add_field("response_format", "json")
+            form_data.add_field("prompt", "")
+            form_data.add_field("language", "en")
+            form_data.add_field("temperature", "0.0")
+
+            async with groq_session.post(
+                url, data=form_data, headers=headers
+            ) as response:
+                if response.status == 404:
+                    logging.error(f"Groq API endpoint not found: {response.url}")
+                    raise aiohttp.ClientResponseError(
+                        response.request_info,
+                        response.history,
+                        status=response.status,
+                        message=response.reason,
+                        headers=response.headers,
+                    )
+                response.raise_for_status()
+                transcription = await response.json()
+                return transcription["text"].lower()
         except aiohttp.ClientResponseError as e:
             logging.error(
                 f"Groq API client error: {e.status}, message='{e.message}', url='{e.request_info.url}'",
@@ -1013,6 +1033,9 @@ def transcribe_with_local_model(audio_buffer, keyword_index):
             prompt = None
 
         try:
+            if model is None:
+                logging.info("Local model not initialized")
+                return ""
             logging.info("using WhisperModel on CUDA")
             # Convert audio buffer (NumPy array) to WAV format in-memory
             byte_io = io.BytesIO()
@@ -1079,15 +1102,25 @@ async def process_audio_async():
             byte_io.seek(0)  # Rewind to the beginning of the byte stream
 
             try:
-                transcript = await transcribe_with_groq_async(byte_io, keyword_index)
-                if transcript is None:
-                    logging.error("Transcription returned None")
-                    continue
+                transcript = None
+                if SETTINGS.get("use_local_gpu", True) and torch.cuda.is_available():
+                    transcript = transcribe_with_local_model(
+                        audio_buffer_for_processing, keyword_index
+                    )
+                    if not transcript or transcript == "Transcription failed":
+                        transcript = None
+                if transcript is None and SETTINGS.get("fallback_to_groq", True):
+                    transcript = await transcribe_with_groq_async(byte_io, keyword_index)
+                    if transcript is None:
+                        logging.error("Transcription returned None")
+                        continue
             except groq.RateLimitError:
                 logging.error(
                     "Groq API rate limit reached, switching to local transcription."
                 )
-                transcript = transcribe_with_local_model(audio_buffer_for_processing)
+                transcript = transcribe_with_local_model(
+                    audio_buffer_for_processing, keyword_index
+                )
 
             transcript_lower = transcript.lower()
 
@@ -1203,9 +1236,10 @@ async def get_transcript_with_retries(byte_io, keyword_index, max_retries=3):
     """Get transcript with retries and fallback"""
     for attempt in range(max_retries):
         try:
-            transcript = await transcribe_with_groq_async(byte_io, keyword_index)
-            if transcript:
-                return transcript.lower()
+            if SETTINGS.get("fallback_to_groq", True):
+                transcript = await transcribe_with_groq_async(byte_io, keyword_index)
+                if transcript:
+                    return transcript.lower()
         except Exception as e:
             logging.error(
                 f"{RED}Transcription attempt {attempt + 1} failed: {e}{RESET}"

--- a/wkey/transcription_config.json
+++ b/wkey/transcription_config.json
@@ -1,0 +1,4 @@
+{
+  "use_local_gpu": true,
+  "fallback_to_groq": true
+}


### PR DESCRIPTION
## Summary
- implement QtPy-based Settings GUI for controlling transcription options
- load transcription settings in whisper scripts
- fall back to API based on new config
- document Settings GUI in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement scipy==1.8.0)*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6864e99fa9608327ad5649ef53060a52